### PR TITLE
use each heading's style in renderHeadingSuggestion, removed heading markers from renderHeadingSuggestion

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"license": "MIT",
 	"dependencies": {
 		"builtin-modules": "^3.3.0",
-		"esbuild": "^0.19.4",
+		"esbuild": "^0.25.8",
 		"obsidian": "^1.4.11",
 		"tslib": "^2.6.2",
 		"typescript": "^5.2.2"

--- a/src/heading_modal.ts
+++ b/src/heading_modal.ts
@@ -111,28 +111,31 @@ export class HeadingModal extends FuzzySuggestModal<Suggestion> {
 		const isSearching = this.inputEl.value.length > 0;
 		const level = s.level;
 		const iconName = level >= 1 && level <= 6 ? `heading-${level}` : "heading";
-
-		if(isSearching) {
+		
+//		if(isSearching) {
 			// Set a heading icon
 			setIcon(el, iconName);
-		} else {
+//		} else {
 			// Use a spacer to represent the heading level
-			el.createDiv({
-				text: "#".repeat(level),
-				cls: "join-gotoheading-headingmodal-suggestion-spacer"
-			});
-		}
+//			el.createDiv({
+//				text: "#".repeat(level),
+//				cls: "join-gotoheading-headingmodal-suggestion-spacer"
+//			});
+//		}
 
 		// Display title as rendered by FuzzySuggestModal
 		const titleEl = el.createSpan({ cls: "title"});
 		super.renderSuggestion(item, titleEl);
 
+		// Apply styles based on heading level
+		titleEl.addClass(`gotoheading-heading-level-${level}`);
+
 		// If a search is ongoing, display parent heading information
 		if(isSearching) {
 			el.createEl("small", { text: this.parentHeadingString(s), cls: "path" });
-		} else {
-			let smallEl = el.createEl("small", { cls: "icon" });
-			setIcon(smallEl, iconName);
+//		} else {
+//			let smallEl = el.createEl("small", { cls: "icon" });
+//			setIcon(smallEl, iconName);
 		}
 	}
 

--- a/src/heading_modal.ts
+++ b/src/heading_modal.ts
@@ -117,12 +117,17 @@ export class HeadingModal extends FuzzySuggestModal<Suggestion> {
 			//setIcon(el, iconName);
 //		} else {
 			// Use a spacer to represent the heading level
-		el.createDiv({
+//		el.createDiv({
 //				text: "#".repeat(level),
-				text: "\u2003".repeat(level-1),
+//				text: "\u2003".repeat(level-1),
 //				cls: "join-gotoheading-headingmodal-suggestion-spacer"
-			});
+//			});
 //		}
+
+		// create indentation before headings relatively
+		el.createSpan({
+			cls: `gotoheading-heading-indentation gotoheading-heading-indentation-level-${level}`
+		});
 		
 		// Display title as rendered by FuzzySuggestModal
 		const titleEl = el.createSpan({ cls: "title"});

--- a/src/heading_modal.ts
+++ b/src/heading_modal.ts
@@ -114,15 +114,16 @@ export class HeadingModal extends FuzzySuggestModal<Suggestion> {
 		
 //		if(isSearching) {
 			// Set a heading icon
-			setIcon(el, iconName);
+			//setIcon(el, iconName);
 //		} else {
 			// Use a spacer to represent the heading level
-//			el.createDiv({
+		el.createDiv({
 //				text: "#".repeat(level),
+				text: "\u2003".repeat(level-1),
 //				cls: "join-gotoheading-headingmodal-suggestion-spacer"
-//			});
+			});
 //		}
-
+		
 		// Display title as rendered by FuzzySuggestModal
 		const titleEl = el.createSpan({ cls: "title"});
 		super.renderSuggestion(item, titleEl);

--- a/styles.css
+++ b/styles.css
@@ -82,3 +82,39 @@
 	color: var(--text-faint);
 	opacity: 0.5;
 }
+
+.join-gotoheading-headingmodal-suggestion .title.gotoheading-heading-level-1 {
+    color: var(--h1-color);
+    font-size: var(--h1-size);
+    font-weight: var(--h1-weight);
+}
+
+.join-gotoheading-headingmodal-suggestion .title.gotoheading-heading-level-2 {
+    color: var(--h2-color);
+    font-size: var(--h2-size);
+    font-weight: var(--h2-weight);
+}
+
+.join-gotoheading-headingmodal-suggestion .title.gotoheading-heading-level-3 {
+    color: var(--h3-color);
+    font-size: var(--h3-size);
+    font-weight: var(--h3-weight);
+}
+
+.join-gotoheading-headingmodal-suggestion .title.gotoheading-heading-level-4 {
+    color: var(--h4-color);
+    font-size: var(--h4-size);
+    font-weight: var(--h4-weight);
+}
+
+.join-gotoheading-headingmodal-suggestion .title.gotoheading-heading-level-5 {
+    color: var(--h5-color);
+    font-size: var(--h5-size);
+    font-weight: var(--h5-weight);
+}
+
+.join-gotoheading-headingmodal-suggestion .title.gotoheading-heading-level-6 {
+    color: var(--h6-color);
+    font-size: var(--h6-size);
+    font-weight: var(--h6-weight);
+}

--- a/styles.css
+++ b/styles.css
@@ -118,3 +118,29 @@
     font-size: var(--h6-size);
     font-weight: var(--h6-weight);
 }
+
+.join-gotoheading-headingmodal-suggestion .gotoheading-heading-indentation {
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.join-gotoheading-headingmodal-suggestion .gotoheading-heading-indentation-level-2 {
+  width: 1em;
+}
+
+.join-gotoheading-headingmodal-suggestion .gotoheading-heading-indentation-level-3 {
+  width: 2em;
+}
+
+.join-gotoheading-headingmodal-suggestion .gotoheading-heading-indentation-level-4 {
+  width: 3em;
+}
+
+.join-gotoheading-headingmodal-suggestion .gotoheading-heading-indentation-level-5 {
+  width: 4em;
+}
+
+.join-gotoheading-headingmodal-suggestion .gotoheading-heading-indentation-level-6 {
+  width: 5em;
+}
+


### PR DESCRIPTION
Hi Oin,
Thank you for making the plugin. It is very useful to me.

I use my custom style for each heading level. For this purpose I update the code.
- Now the plugin uses each heading's style in renderHeadingSuggestion(). Correspondingly, the needed CSS code is added for six heading levels. 
- Heading markers ('##..') are removed from renderHeadingSuggestion(). Instead, heading icons show up at the beginning.

This update can resolve #9.

Please consider this PR.

Thank you,
Kyd